### PR TITLE
Readme updates; improved instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,22 @@
-Send WebMentions via a "comment" like form:
 
+## Description ##
+Allow users to comment on their own website and post it to your site using <a href="https://indieweb.org/webmention">WebMentions</a> via a "comment" like form:
+
+![webmention form](https://cloud.githubusercontent.com/assets/5882943/17355330/a5bed972-5904-11e6-84d6-1c604533834f.PNG)
+_Screenshot of form added below usual comment box._
+
+
+## Inspiration ##
+Originally inspired by:
 * http://adactio.com/journal/6469/
 * http://adactio.com/journal/6495/
 
-The plugin only works in combination with the [WebMention plugin](https://github.com/pfefferle/wordpress-webmention) for WordPress
+## Installation ##
+
+1. Upload the `wordpress-webmention-form`-folder to the `/wp-content/plugins/` directory
+2. Activate the plugin through the *Plugins* menu in WordPress
+3. ...and that's it :)
+
+The plugin only works in combination with the [WebMention plugin](https://github.com/pfefferle/wordpress-webmention) for WordPress.
+
+For additional plugins which expand on this type of web functionality/architecture, please try out the <a href="https://wordpress.org/plugins/indieweb/">Indieweb Plugin</a> in the WordPress.org repository and visit <a href="http://indieweb.org">Indieweb.org</a> for additional details.

--- a/webmention-comment-form-template.php
+++ b/webmention-comment-form-template.php
@@ -1,6 +1,6 @@
 <form id="webmention-form" action="<?php echo site_url( '?webmention=endpoint' ); ?>" method="post">
 	<p>
-		<label for="webmention-source"><?php _e( 'Responding with a post on your own blog? Send me a <a href="http://indiewebcamp.com/webmention">WebMention</a> <sup>(<a href="http://adactio.com/journal/6469/">?</a>)</sup>', 'webmention_form' ); ?></label>
+		<label for="webmention-source"><?php _e( 'Responding with a post on your own blog? Send me a <a href="http://indieweb.org/webmention">WebMention</a> by writing something on your website that links to this post and then enter your post URL below.', 'webmention_form' ); ?></label>
 		<input id="webmention-source" type="url" name="source" placeholder="URL/Permalink of your article" />
 	</p>
 	<p>

--- a/webmention-form-template.php
+++ b/webmention-form-template.php
@@ -9,7 +9,7 @@
 	<body>
 		<h1><?php _e( 'Send a WebMention', 'webmention_form' ); ?></h1>
 		<p>
-			<?php _e( 'Responding with a post on your own blog? Send me a <a href="http://indiewebcamp.com/webmention">WebMention</a> <sup>(<a href="http://adactio.com/journal/6469/">?</a>)</sup>', 'webmention_form' ); ?>
+			<?php _e( 'Responding with a post on your own blog? Send me a <a href="http://indieweb.org/webmention">WebMention</a> by writing something on your website that links to this post and then enter your post URL below.', 'webmention_form' ); ?>
 		</p>
 
 		<?php do_action( 'webmention_form_before_form' ); ?>


### PR DESCRIPTION
## What I changed

Added material for the readme to improve description of plugin, included a photo of the functionality, as well as installation instructions and pointers for additional IndieWeb resources in the bigger suite of tools.

Updated URL references from IndieWebCamp.com to IndieWeb.org.

Changed the instructional display that appears on the comment form to provide better succinct instructions to end users attempting to webmention using the URL form. Removed the reference to adactio's site as it's likely to confuse most users, but did mirror some of the language of his post to rewrite the instructions.
